### PR TITLE
Enigma.io to Enigma

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Preview | Description
 * [data.gov](https://catalog.data.gov/dataset) - The home of the U.S. Government's open data
 * [United States Census Bureau](http://www.census.gov/)
 * [usgovxml.com](http://usgovxml.com/)
-* [enigma.io](http://enigma.io/) - Navigate the world of public data - Quickly search and analyze billions of public records published  by governments, companies and organizations.
+* [enigma.com](http://enigma.com/) - Navigate the world of public data - Quickly search and analyze billions of public records published  by governments, companies and organizations.
 * [datahub.io](https://datahub.io/)
 * [aws.amazon.com/datasets](https://aws.amazon.com/datasets/)
 * [databib.org](http://databib.org/)


### PR DESCRIPTION
Hi Hüseyin,

We have moved away from Enigma.io to Enigma as of a few months ago and we are cleaning up the lingering enigma.ios that still persist across the internet. Please accept my proposed change.

Kindest,

India Kerle